### PR TITLE
feat: get media by season is adult option

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -112,7 +112,7 @@ Get anime/manga for a specific season + year.
 
 | Param | Type |
 | --- | --- |
-| `options` | `GetSeasonOptions` (season, seasonYear, type?, sort?, page?, perPage?) |
+| `options` | `GetSeasonOptions` (season, seasonYear, type?, isAdult?, sort?, page?, perPage?) |
 
 **Returns:** `Promise<PagedResult<Media>>`
 

--- a/src/client/media.ts
+++ b/src/client/media.ts
@@ -185,6 +185,7 @@ export async function getMediaBySeason(client: ClientBase, options: GetSeasonOpt
       season: options.season,
       seasonYear: options.seasonYear,
       type: options.type,
+      isAdult: options.isAdult ?? false,
       sort: options.sort,
       page: options.page ?? 1,
       perPage: clampPerPage(options.perPage ?? 20),

--- a/src/queries/media.ts
+++ b/src/queries/media.ts
@@ -101,10 +101,24 @@ query ($type: MediaType, $sort: [MediaSort], $page: Int, $perPage: Int) {
 }`;
 
 export const QUERY_MEDIA_BY_SEASON = `
-query ($season: MediaSeason!, $seasonYear: Int!, $type: MediaType, $sort: [MediaSort], $page: Int, $perPage: Int) {
+query (
+  $season: MediaSeason!,
+  $seasonYear: Int!,
+  $type: MediaType,
+  $isAdult: Boolean,
+  $sort: [MediaSort],
+  $page: Int,
+  $perPage: Int
+) {
   Page(page: $page, perPage: $perPage) {
     pageInfo { total perPage currentPage lastPage hasNextPage }
-    media(season: $season, seasonYear: $seasonYear, type: $type, sort: $sort) {
+    media(
+      season: $season,
+      seasonYear: $seasonYear,
+      type: $type,
+      isAdult: $isAdult,
+      sort: $sort
+    ) {
       ${MEDIA_FIELDS_BASE}
     }
   }

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -345,6 +345,8 @@ export interface GetSeasonOptions {
   seasonYear: number;
   /** Filter by ANIME or MANGA (defaults to ANIME) */
   type?: MediaType;
+  /** Allow or disallow explicit content (defaults to False) */
+  isAdult?: boolean;
   /** Sort order (default: POPULARITY_DESC) */
   sort?: MediaSort[];
   page?: number;


### PR DESCRIPTION
I took a stab at adding a isAdult parameter to the getMediaBySeason endpoint. Pretty sure this works correctly, although first time messing with this so not sure.

Also the variable defaults to false when not provided, so that by default explicit content is filtered out.

I did not update the unit test for this as this is just adding an optional parameter and the unit test written just uses the required parameters.

Let me know if I missed something, since I'm not too familiar with GraphQL, but hopefully I get more familiar the more I do these and I can add more features and parameters as I need them.