### PR TITLE
feat: Added isAdult option to many different endpoints

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -74,9 +74,15 @@ const result = await client.searchMedia({
 });
 ```
 
-### `getTrending(type?, page?, perPage?)`
+### `getTrending(options?)`
 
 Get currently trending anime or manga.
+
+| Param | Type |
+| --- | --- |
+| `options` | `GeneralMediaQueryOptions` |
+
+**Key options:** `type`, `isAdult`, `page`, `perPage`
 
 **Returns:** `Promise<PagedResult<Media>>`
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -150,7 +150,7 @@ Get recently aired anime episodes (default: last 24 hours).
 
 | Param | Type |
 | --- | --- |
-| `options` | `GetAiringOptions` (airingAtGreater?, airingAtLesser?, sort?, page?, perPage?) |
+| `options` | `GetAiringOptions` (airingAtGreater?, airingAtLesser?, isAdult?, sort?, page?, perPage?) |
 
 **Returns:** `Promise<PagedResult<AiringSchedule>>`
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -86,9 +86,15 @@ Get currently trending anime or manga.
 
 **Returns:** `Promise<PagedResult<Media>>`
 
-### `getPopular(type?, page?, perPage?)`
+### `getPopular(options?)`
 
 Get the most popular anime or manga. Convenience wrapper around `searchMedia` with `POPULARITY_DESC` sort.
+
+| Param | Type |
+| --- | --- |
+| `options` | `GeneralMediaQueryOptions` |
+
+**Key options:** `type`, `isAdult`, `page`, `perPage`
 
 **Returns:** `Promise<PagedResult<Media>>`
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -140,7 +140,7 @@ Get upcoming (not yet released) media sorted by popularity.
 
 | Param | Type |
 | --- | --- |
-| `options` | `GetPlanningOptions` (type?, sort?, page?, perPage?) |
+| `options` | `GetPlanningOptions` (type?, isAdult?, sort?, page?, perPage?) |
 
 **Returns:** `Promise<PagedResult<Media>>`
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -118,7 +118,7 @@ Get the highest-rated anime or manga. Convenience wrapper around `searchMedia` w
 const top = await client.getTopRated(MediaType.MANGA, 1, 10);
 ```
 
-### `getWeeklySchedule(date?)`
+### `getWeeklySchedule(date?, isAdult?)`
 
 Fetches the airing schedule for the entire week of the specified date (defaults to the current week). Returns a `WeeklySchedule` object grouped by day of the week.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -158,6 +158,10 @@ Get recently aired anime episodes (default: last 24 hours).
 
 Get currently releasing manga sorted by most recently updated.
 
+| Param | Type |
+| --- | --- |
+| `options` | `GetAiringOptions` (isAdult?, page?, perPage?) |
+
 **Returns:** `Promise<PagedResult<Media>>`
 
 ::: warning Deprecation

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -102,9 +102,15 @@ Get the most popular anime or manga. Convenience wrapper around `searchMedia` wi
 const popular = await client.getPopular(MediaType.ANIME, 1, 10);
 ```
 
-### `getTopRated(type?, page?, perPage?)`
+### `getTopRated(options?)`
 
 Get the highest-rated anime or manga. Convenience wrapper around `searchMedia` with `SCORE_DESC` sort.
+
+| Param | Type |
+| --- | --- |
+| `options` | `GeneralMediaQueryOptions` |
+
+**Key options:** `type`, `isAdult`, `page`, `perPage`
 
 **Returns:** `Promise<PagedResult<Media>>`
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -268,8 +268,8 @@ export class AniListClient {
   }
 
   /** Get the highest-rated anime or manga. */
-  async getTopRated(type?: MediaType, page?: number, perPage?: number): Promise<PagedResult<Media>> {
-    return mediaMethods.getTopRated(this, type, page, perPage);
+  async getTopRated(options: GeneralMediaQueryOptions = {}): Promise<PagedResult<Media>> {
+    return mediaMethods.getTopRated(this, options);
   }
 
   /** Get recently aired anime episodes. */

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -263,8 +263,8 @@ export class AniListClient {
   }
 
   /** Get the most popular anime or manga. */
-  async getPopular(type?: MediaType, page?: number, perPage?: number): Promise<PagedResult<Media>> {
-    return mediaMethods.getPopular(this, type, page, perPage);
+  async getPopular(options: GeneralMediaQueryOptions = {}): Promise<PagedResult<Media>> {
+    return mediaMethods.getPopular(this, options);
   }
 
   /** Get the highest-rated anime or manga. */

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -15,6 +15,7 @@ import type {
   CacheAdapter,
   Character,
   CharacterIncludeOptions,
+  GeneralMediaQueryOptions,
   GetAiringOptions,
   GetPlanningOptions,
   GetRecentChaptersOptions,
@@ -257,8 +258,8 @@ export class AniListClient {
   }
 
   /** Get currently trending anime or manga. */
-  async getTrending(type?: MediaType, page?: number, perPage?: number): Promise<PagedResult<Media>> {
-    return mediaMethods.getTrending(this, type, page, perPage);
+  async getTrending(options: GeneralMediaQueryOptions = {}): Promise<PagedResult<Media>> {
+    return mediaMethods.getTrending(this, options);
   }
 
   /** Get the most popular anime or manga. */

--- a/src/client/media.ts
+++ b/src/client/media.ts
@@ -86,13 +86,9 @@ export async function getPopular(client: ClientBase, options: GeneralMediaQueryO
   return searchMedia(client, { type, isAdult, sort: [MediaSort.POPULARITY_DESC], page, perPage });
 }
 
-export async function getTopRated(
-  client: ClientBase,
-  type: MediaType = MediaType.ANIME,
-  page = 1,
-  perPage = 20,
-): Promise<PagedResult<Media>> {
-  return searchMedia(client, { type, sort: [MediaSort.SCORE_DESC], page, perPage });
+export async function getTopRated(client: ClientBase, options: GeneralMediaQueryOptions): Promise<PagedResult<Media>> {
+  const { type = MediaType.ANIME, isAdult = false, page = 1, perPage = 20 } = options;
+  return searchMedia(client, { type, isAdult, sort: [MediaSort.SCORE_DESC], page, perPage });
 }
 
 export async function getAiredEpisodes(

--- a/src/client/media.ts
+++ b/src/client/media.ts
@@ -101,6 +101,7 @@ export async function getAiredEpisodes(
     {
       airingAt_greater: options.airingAtGreater ?? now - 24 * 3600,
       airingAt_lesser: options.airingAtLesser ?? now,
+      isAdult: options.isAdult ?? false,
       sort: options.sort,
       page: options.page ?? 1,
       perPage: clampPerPage(options.perPage ?? 20),

--- a/src/client/media.ts
+++ b/src/client/media.ts
@@ -184,7 +184,11 @@ export async function getMediaBySeason(client: ClientBase, options: GetSeasonOpt
   );
 }
 
-export async function getWeeklySchedule(client: ClientBase, date: Date = new Date()): Promise<WeeklySchedule> {
+export async function getWeeklySchedule(
+  client: ClientBase,
+  date: Date = new Date(),
+  isAdult: boolean = false,
+): Promise<WeeklySchedule> {
   const schedule: WeeklySchedule = {
     Monday: [],
     Tuesday: [],
@@ -211,6 +215,7 @@ export async function getWeeklySchedule(client: ClientBase, date: Date = new Dat
       getAiredEpisodes(client, {
         airingAtGreater: startTimestamp,
         airingAtLesser: endTimestamp,
+        isAdult,
         page,
         perPage: 50,
       }),

--- a/src/client/media.ts
+++ b/src/client/media.ts
@@ -12,6 +12,7 @@ import {
 import type {
   AiringSchedule,
   DayOfWeek,
+  GeneralMediaQueryOptions,
   GetAiringOptions,
   GetPlanningOptions,
   GetRecentChaptersOptions,
@@ -75,13 +76,9 @@ export async function searchMedia(client: ClientBase, options: SearchMediaOption
   );
 }
 
-export async function getTrending(
-  client: ClientBase,
-  type: MediaType = MediaType.ANIME,
-  page = 1,
-  perPage = 20,
-): Promise<PagedResult<Media>> {
-  return client.pagedRequest<Media>(QUERY_TRENDING, { type, page, perPage: clampPerPage(perPage) }, "media");
+export async function getTrending(client: ClientBase, options: GeneralMediaQueryOptions): Promise<PagedResult<Media>> {
+  const { type = MediaType.ANIME, isAdult = false, page = 1, perPage = 20 } = options;
+  return client.pagedRequest<Media>(QUERY_TRENDING, { type, isAdult, page, perPage: clampPerPage(perPage) }, "media");
 }
 
 export async function getPopular(

--- a/src/client/media.ts
+++ b/src/client/media.ts
@@ -81,13 +81,9 @@ export async function getTrending(client: ClientBase, options: GeneralMediaQuery
   return client.pagedRequest<Media>(QUERY_TRENDING, { type, isAdult, page, perPage: clampPerPage(perPage) }, "media");
 }
 
-export async function getPopular(
-  client: ClientBase,
-  type: MediaType = MediaType.ANIME,
-  page = 1,
-  perPage = 20,
-): Promise<PagedResult<Media>> {
-  return searchMedia(client, { type, sort: [MediaSort.POPULARITY_DESC], page, perPage });
+export async function getPopular(client: ClientBase, options: GeneralMediaQueryOptions): Promise<PagedResult<Media>> {
+  const { type = MediaType.ANIME, isAdult = false, page = 1, perPage = 20 } = options;
+  return searchMedia(client, { type, isAdult, sort: [MediaSort.POPULARITY_DESC], page, perPage });
 }
 
 export async function getTopRated(

--- a/src/client/media.ts
+++ b/src/client/media.ts
@@ -134,6 +134,7 @@ export async function getPlanning(client: ClientBase, options: GetPlanningOption
     QUERY_PLANNING,
     {
       type: options.type,
+      isAdult: options.isAdult ?? false,
       sort: options.sort ?? [MediaSort.POPULARITY_DESC],
       page: options.page ?? 1,
       perPage: clampPerPage(options.perPage ?? 20),

--- a/src/client/media.ts
+++ b/src/client/media.ts
@@ -122,6 +122,7 @@ export async function getRecentlyUpdatedManga(
   return client.pagedRequest<Media>(
     QUERY_RECENT_CHAPTERS,
     {
+      isAdult: options.isAdult ?? false,
       page: options.page ?? 1,
       perPage: clampPerPage(options.perPage ?? 20),
     },

--- a/src/queries/media.ts
+++ b/src/queries/media.ts
@@ -54,10 +54,10 @@ query (
 }`;
 
 export const QUERY_TRENDING = `
-query ($type: MediaType, $page: Int, $perPage: Int) {
+query ($type: MediaType, $isAdult: Boolean, $page: Int, $perPage: Int) {
   Page(page: $page, perPage: $perPage) {
     pageInfo { total perPage currentPage lastPage hasNextPage }
-    media(type: $type, sort: TRENDING_DESC) {
+    media(type: $type, isAdult: $isAdult, sort: TRENDING_DESC) {
       ${MEDIA_FIELDS_BASE}
     }
   }

--- a/src/queries/media.ts
+++ b/src/queries/media.ts
@@ -81,10 +81,10 @@ query ($airingAt_greater: Int, $airingAt_lesser: Int, $isAdult: Boolean, $sort: 
 }`;
 
 export const QUERY_RECENT_CHAPTERS = `
-query ($page: Int, $perPage: Int) {
+query ($isAdult: Boolean $page: Int, $perPage: Int) {
   Page(page: $page, perPage: $perPage) {
     pageInfo { total perPage currentPage lastPage hasNextPage }
-    media(type: MANGA, status: RELEASING, sort: UPDATED_AT_DESC) {
+    media(type: MANGA, isAdult: $isAdult status: RELEASING, sort: UPDATED_AT_DESC) {
       ${MEDIA_FIELDS_BASE}
     }
   }

--- a/src/queries/media.ts
+++ b/src/queries/media.ts
@@ -91,10 +91,10 @@ query ($page: Int, $perPage: Int) {
 }`;
 
 export const QUERY_PLANNING = `
-query ($type: MediaType, $sort: [MediaSort], $page: Int, $perPage: Int) {
+query ($type: MediaType, $isAdult: Boolean, $sort: [MediaSort], $page: Int, $perPage: Int) {
   Page(page: $page, perPage: $perPage) {
     pageInfo { total perPage currentPage lastPage hasNextPage }
-    media(type: $type, status: NOT_YET_RELEASED, sort: $sort) {
+    media(type: $type, isAdult: $isAdult, status: NOT_YET_RELEASED, sort: $sort) {
       ${MEDIA_FIELDS_BASE}
     }
   }

--- a/src/queries/media.ts
+++ b/src/queries/media.ts
@@ -64,7 +64,7 @@ query ($type: MediaType, $isAdult: Boolean, $page: Int, $perPage: Int) {
 }`;
 
 export const QUERY_AIRING_SCHEDULE = `
-query ($airingAt_greater: Int, $airingAt_lesser: Int, $sort: [AiringSort], $page: Int, $perPage: Int) {
+query ($airingAt_greater: Int, $airingAt_lesser: Int, $isAdult: Boolean, $sort: [AiringSort], $page: Int, $perPage: Int) {
   Page(page: $page, perPage: $perPage) {
     pageInfo { total perPage currentPage lastPage hasNextPage }
     airingSchedules(airingAt_greater: $airingAt_greater, airingAt_lesser: $airingAt_lesser, sort: $sort) {
@@ -73,7 +73,7 @@ query ($airingAt_greater: Int, $airingAt_lesser: Int, $sort: [AiringSort], $page
       timeUntilAiring
       episode
       mediaId
-      media {
+      media(isAdult: $isAdult) {
         ${MEDIA_FIELDS_BASE}
       }
     }

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -310,6 +310,8 @@ export interface GetAiringOptions {
   airingAtGreater?: number;
   /** Only show episodes that aired before this UNIX timestamp */
   airingAtLesser?: number;
+  /** Include or Exclude explicit content (default: false) */
+  isAdult?: boolean;
   /** Sort order (default: TIME_DESC) */
   sort?: AiringSort[];
   /** Page number */

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -258,12 +258,19 @@ export interface Media {
 }
 
 export interface SearchMediaOptions {
+  /** Search Term */
   query?: string;
+  /** Filter by country code (e.g., "JP", "KR") */
   countryOfOrigin?: string;
+  /** Filter by Anime or Manga */
   type?: MediaType;
+  /** Filter by format (For multiple formats: [MediaFormat.TV]) */
   format?: MediaFormat | MediaFormat[];
+  /** Filter by status of Media */
   status?: MediaStatus;
+  /** Filter by Season (Winter, Spring, Summer, Fall) */
   season?: MediaSeason;
+  /** Filter by Year */
   seasonYear?: number;
   /** Single genre filter (kept for backward compat) */
   genre?: string;
@@ -277,16 +284,24 @@ export interface SearchMediaOptions {
   genresExclude?: string[];
   /** Exclude media with any of these tags */
   tagsExclude?: string[];
+  /** Include or Exclude explicit content (default: false) */
   isAdult?: boolean;
+  /** Sort order */
   sort?: MediaSort[];
+  /** Page number */
   page?: number;
+  /** Results per page (max 50) */
   perPage?: number;
 }
 
 export interface GeneralMediaQueryOptions {
+  /** Filter by Anime or Manga */
   type?: MediaType;
+  /** Include or Exclude explicit content (default: false) */
   isAdult?: boolean;
+  /** Page number */
   page?: number;
+  /** Results per page (max 50) */
   perPage?: number;
 }
 
@@ -297,7 +312,9 @@ export interface GetAiringOptions {
   airingAtLesser?: number;
   /** Sort order (default: TIME_DESC) */
   sort?: AiringSort[];
+  /** Page number */
   page?: number;
+  /** Results per page (max 50) */
   perPage?: number;
 }
 
@@ -313,7 +330,9 @@ export interface GetPlanningOptions {
   type?: MediaType;
   /** Sort order (default: POPULARITY_DESC) */
   sort?: MediaSort[];
+  /** Page number */
   page?: number;
+  /** Results per page (max 50) */
   perPage?: number;
 }
 
@@ -341,7 +360,9 @@ export interface GetRecommendationsOptions {
   mediaId: number;
   /** Sort order (default: RATING_DESC) */
   sort?: RecommendationSort[];
+  /** Page number */
   page?: number;
+  /** Results per page (max 50) */
   perPage?: number;
 }
 
@@ -356,7 +377,9 @@ export interface GetSeasonOptions {
   isAdult?: boolean;
   /** Sort order (default: POPULARITY_DESC) */
   sort?: MediaSort[];
+  /** Page number */
   page?: number;
+  /** Results per page (max 50) */
   perPage?: number;
 }
 

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -330,6 +330,8 @@ export interface GetRecentChaptersOptions {
 export interface GetPlanningOptions {
   /** Filter by ANIME or MANGA (returns both if omitted) */
   type?: MediaType;
+  /** Include or Exclude explicit content (default: false) */
+  isAdult?: boolean;
   /** Sort order (default: POPULARITY_DESC) */
   sort?: MediaSort[];
   /** Page number */

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -321,6 +321,8 @@ export interface GetAiringOptions {
 }
 
 export interface GetRecentChaptersOptions {
+  /** Include or Exclude explicit content (default: false) */
+  isAdult?: boolean;
   /** Page number (default: 1) */
   page?: number;
   /** Results per page (default: 20, max 50) */

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -283,6 +283,13 @@ export interface SearchMediaOptions {
   perPage?: number;
 }
 
+export interface GeneralMediaQueryOptions {
+  type?: MediaType;
+  isAdult?: boolean;
+  page?: number;
+  perPage?: number;
+}
+
 export interface GetAiringOptions {
   /** Only show episodes that aired after this UNIX timestamp */
   airingAtGreater?: number;

--- a/tests/integration/client.test.ts
+++ b/tests/integration/client.test.ts
@@ -44,18 +44,18 @@ describe("AniListClient (integration)", () => {
     });
 
     it("getTrending(ANIME)", async () => {
-      const result = await client.getTrending(MediaType.ANIME, 1, 5);
+      const result = await client.getTrending({ type: MediaType.ANIME, page: 1, perPage: 5 });
       expect(result.results.length).toBeGreaterThan(0);
       expect(result.pageInfo.hasNextPage).not.toBeNull();
     });
 
     it("getPopular(ANIME)", async () => {
-      const result = await client.getPopular(MediaType.ANIME, 1, 5);
+      const result = await client.getPopular({ type: MediaType.ANIME, page: 1, perPage: 5 });
       expect(result.results.length).toBeGreaterThan(0);
     });
 
     it("getTopRated(ANIME)", async () => {
-      const result = await client.getTopRated(MediaType.ANIME, 1, 5);
+      const result = await client.getTopRated({ type: MediaType.ANIME, page: 1, perPage: 5 });
       expect(result.results.length).toBeGreaterThan(0);
     });
   });
@@ -394,7 +394,10 @@ describe("AniListClient (integration)", () => {
   describe("Paginate", () => {
     it("paginate() iterates across pages", async () => {
       const items: string[] = [];
-      for await (const anime of client.paginate((page) => client.getTrending(MediaType.ANIME, page, 3), 2)) {
+      for await (const anime of client.paginate(
+        (page) => client.getTrending({ type: MediaType.ANIME, page, perPage: 3 }),
+        2,
+      )) {
         items.push(anime.title.romaji ?? "?");
       }
       expect(items.length).toBeGreaterThan(3);

--- a/tests/unit/__snapshots__/snapshots.test.ts.snap
+++ b/tests/unit/__snapshots__/snapshots.test.ts.snap
@@ -248,10 +248,10 @@ query ($search: String, $sort: [StudioSort], $page: Int, $perPage: Int) {
 
 exports[`query snapshots > QUERY_TRENDING matches snapshot 1`] = `
 "
-query ($type: MediaType, $page: Int, $perPage: Int) {
+query ($type: MediaType, $isAdult: Boolean, $page: Int, $perPage: Int) {
   Page(page: $page, perPage: $perPage) {
     pageInfo { total perPage currentPage lastPage hasNextPage }
-    media(type: $type, sort: TRENDING_DESC) {
+    media(type: $type, isAdult: $isAdult, sort: TRENDING_DESC) {
       
   id
   idMal

--- a/tests/unit/__snapshots__/snapshots.test.ts.snap
+++ b/tests/unit/__snapshots__/snapshots.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`query snapshots > QUERY_AIRING_SCHEDULE matches snapshot 1`] = `
 "
-query ($airingAt_greater: Int, $airingAt_lesser: Int, $sort: [AiringSort], $page: Int, $perPage: Int) {
+query ($airingAt_greater: Int, $airingAt_lesser: Int, $isAdult: Boolean, $sort: [AiringSort], $page: Int, $perPage: Int) {
   Page(page: $page, perPage: $perPage) {
     pageInfo { total perPage currentPage lastPage hasNextPage }
     airingSchedules(airingAt_greater: $airingAt_greater, airingAt_lesser: $airingAt_lesser, sort: $sort) {
@@ -11,7 +11,7 @@ query ($airingAt_greater: Int, $airingAt_lesser: Int, $sort: [AiringSort], $page
       timeUntilAiring
       episode
       mediaId
-      media {
+      media(isAdult: $isAdult) {
         
   id
   idMal


### PR DESCRIPTION
Closes #60 

I added the isAdult option to many different endpoints which include: getTrending, getPopular, getTopRated, getWeeklySchedule, getPlanning, getAiredEpisodes, and getRecentlyUpdatedManga.

When isAdult option is not provided, it defaults to false.

Also GeneralMediaQueryOptions type was created for getTrending, getPopular, and getTopRated.

Also some more JS Doc comments were added for types.