### PR TITLE
fix: update rate limit to respect new anilist rate limit

### DIFF
--- a/docs/guide/rate-limiting.md
+++ b/docs/guide/rate-limiting.md
@@ -12,7 +12,7 @@ head:
 
 # Rate Limiting
 
-The client respects AniList's rate limit (90 req/min) with a conservative default of **85 req/min**.
+The client respects AniList's rate limit (30 req/min) with a conservative default of **25 req/min**.
 
 When an HTTP 429 response is received, the client pauses and retries automatically using **exponential backoff with jitter**.
 

--- a/src/rate-limiter/index.ts
+++ b/src/rate-limiter/index.ts
@@ -1,7 +1,7 @@
 /**
  * Rate limiter with automatic retry for AniList API.
  *
- * AniList allows 90 requests per minute.
+ * AniList allows 30 requests per minute.
  * When a 429 (Too Many Requests) is received, the client
  * waits for the Retry-After header and retries automatically.
  */
@@ -28,7 +28,7 @@ export class RateLimiter {
   private readonly activeTimers = new Set<ReturnType<typeof setTimeout>>();
 
   constructor(options: RateLimitOptions = {}) {
-    this.maxRequests = options.maxRequests ?? 85;
+    this.maxRequests = options.maxRequests ?? 25;
     this.windowMs = options.windowMs ?? 60_000;
     this.maxRetries = options.maxRetries ?? 3;
     this.retryDelayMs = options.retryDelayMs ?? 2_000;


### PR DESCRIPTION
Closes #70 

Updated default rate limit from 85 to 25 due to new AniList rate limit of 30 per minute.