### PR TITLE
feat: Added in extraLarge cover image for relations_fields & other relevant fields

### DIFF
--- a/src/queries/fragments.ts
+++ b/src/queries/fragments.ts
@@ -83,7 +83,17 @@ export const RELATIONS_FIELDS = `
         type
         format
         status
-        coverImage { extraLarge large medium }
+        startDate { year month day }
+        endDate { year month day }
+        season
+        seasonYear
+        episodes
+        chapters
+        volumes
+        coverImage { extraLarge large medium color }
+        genres
+        averageScore
+        studios { nodes { id name isAnimationStudio siteUrl } }
         siteUrl
       }
     }

--- a/src/queries/fragments.ts
+++ b/src/queries/fragments.ts
@@ -83,7 +83,7 @@ export const RELATIONS_FIELDS = `
         type
         format
         status
-        coverImage { large medium }
+        coverImage { extraLarge large medium }
         siteUrl
       }
     }

--- a/tests/unit/__snapshots__/snapshots.test.ts.snap
+++ b/tests/unit/__snapshots__/snapshots.test.ts.snap
@@ -117,7 +117,7 @@ query ($idMal: Int!, $type: MediaType) {
         type
         format
         status
-        coverImage { large medium }
+        coverImage { extraLarge large medium }
         siteUrl
       }
     }
@@ -434,7 +434,7 @@ exports[`query snapshots > buildBatchMediaQuery matches snapshot 1`] = `
         type
         format
         status
-        coverImage { large medium }
+        coverImage { extraLarge large medium }
         siteUrl
       }
     }
@@ -494,7 +494,7 @@ exports[`query snapshots > buildBatchMediaQuery matches snapshot 1`] = `
         type
         format
         status
-        coverImage { large medium }
+        coverImage { extraLarge large medium }
         siteUrl
       }
     }
@@ -554,7 +554,7 @@ exports[`query snapshots > buildBatchMediaQuery matches snapshot 1`] = `
         type
         format
         status
-        coverImage { large medium }
+        coverImage { extraLarge large medium }
         siteUrl
       }
     }
@@ -659,7 +659,7 @@ query ($id: Int!) {
         type
         format
         status
-        coverImage { large medium }
+        coverImage { extraLarge large medium }
         siteUrl
       }
     }
@@ -870,7 +870,7 @@ query ($id: Int!) {
         type
         format
         status
-        coverImage { large medium }
+        coverImage { extraLarge large medium }
         siteUrl
       }
     }

--- a/tests/unit/__snapshots__/snapshots.test.ts.snap
+++ b/tests/unit/__snapshots__/snapshots.test.ts.snap
@@ -117,7 +117,17 @@ query ($idMal: Int!, $type: MediaType) {
         type
         format
         status
-        coverImage { extraLarge large medium }
+        startDate { year month day }
+        endDate { year month day }
+        season
+        seasonYear
+        episodes
+        chapters
+        volumes
+        coverImage { extraLarge large medium color }
+        genres
+        averageScore
+        studios { nodes { id name isAnimationStudio siteUrl } }
         siteUrl
       }
     }
@@ -434,7 +444,17 @@ exports[`query snapshots > buildBatchMediaQuery matches snapshot 1`] = `
         type
         format
         status
-        coverImage { extraLarge large medium }
+        startDate { year month day }
+        endDate { year month day }
+        season
+        seasonYear
+        episodes
+        chapters
+        volumes
+        coverImage { extraLarge large medium color }
+        genres
+        averageScore
+        studios { nodes { id name isAnimationStudio siteUrl } }
         siteUrl
       }
     }
@@ -494,7 +514,17 @@ exports[`query snapshots > buildBatchMediaQuery matches snapshot 1`] = `
         type
         format
         status
-        coverImage { extraLarge large medium }
+        startDate { year month day }
+        endDate { year month day }
+        season
+        seasonYear
+        episodes
+        chapters
+        volumes
+        coverImage { extraLarge large medium color }
+        genres
+        averageScore
+        studios { nodes { id name isAnimationStudio siteUrl } }
         siteUrl
       }
     }
@@ -554,7 +584,17 @@ exports[`query snapshots > buildBatchMediaQuery matches snapshot 1`] = `
         type
         format
         status
-        coverImage { extraLarge large medium }
+        startDate { year month day }
+        endDate { year month day }
+        season
+        seasonYear
+        episodes
+        chapters
+        volumes
+        coverImage { extraLarge large medium color }
+        genres
+        averageScore
+        studios { nodes { id name isAnimationStudio siteUrl } }
         siteUrl
       }
     }
@@ -659,7 +699,17 @@ query ($id: Int!) {
         type
         format
         status
-        coverImage { extraLarge large medium }
+        startDate { year month day }
+        endDate { year month day }
+        season
+        seasonYear
+        episodes
+        chapters
+        volumes
+        coverImage { extraLarge large medium color }
+        genres
+        averageScore
+        studios { nodes { id name isAnimationStudio siteUrl } }
         siteUrl
       }
     }
@@ -870,7 +920,17 @@ query ($id: Int!) {
         type
         format
         status
-        coverImage { extraLarge large medium }
+        startDate { year month day }
+        endDate { year month day }
+        season
+        seasonYear
+        episodes
+        chapters
+        volumes
+        coverImage { extraLarge large medium color }
+        genres
+        averageScore
+        studios { nodes { id name isAnimationStudio siteUrl } }
         siteUrl
       }
     }


### PR DESCRIPTION
I've noticed that relation edges do not include the extralarge cover image, just large and medium.

I've changed the Relation_Fields to include the extraLarge cover image accordingly.

I have not updated any of the docs, as there did not seem to be any part specifically for relation type.

Update: I also added in more fields that I have found would be useful for in displaying relations information for specific media.