### PR TITLE
More Media Recommendation Fields; Mean Score for MediaEdge

### DIFF
--- a/src/queries/builders.ts
+++ b/src/queries/builders.ts
@@ -5,6 +5,7 @@ import {
   CHARACTER_FIELDS_COMPACT,
   MEDIA_FIELDS,
   MEDIA_FIELDS_BASE,
+  MEDIA_RECOMMENDATION_FIELDS,
   RELATIONS_FIELDS,
   STAFF_FIELDS,
   VOICE_ACTOR_FIELDS_COMPACT,
@@ -70,17 +71,7 @@ export function buildMediaByIdQuery(include?: MediaIncludeOptions): string {
     extra.push(`
     recommendations(perPage: ${perPage}, sort: [RATING_DESC]) {
       nodes {
-        id
-        rating
-        mediaRecommendation {
-          id
-          title { romaji english native userPreferred }
-          type
-          format
-          coverImage { large medium }
-          averageScore
-          siteUrl
-        }
+        ${MEDIA_RECOMMENDATION_FIELDS}
       }
     }`);
   }

--- a/src/queries/fragments.ts
+++ b/src/queries/fragments.ts
@@ -93,6 +93,7 @@ export const RELATIONS_FIELDS = `
         coverImage { extraLarge large medium color }
         genres
         averageScore
+        meanScore
         studios { nodes { id name isAnimationStudio siteUrl } }
         siteUrl
         nextAiringEpisode {

--- a/src/queries/fragments.ts
+++ b/src/queries/fragments.ts
@@ -107,6 +107,32 @@ export const RELATIONS_FIELDS = `
   }
 `;
 
+/** Media Recommendation fields - used for when fetching recommendation for a specific media entry */
+export const MEDIA_RECOMMENDATION_FIELDS = `
+  id
+  rating
+  mediaRecommendation {
+    id
+    title { romaji english native userPreferred }
+    type
+    format
+    coverImage { large medium }
+    averageScore
+    meanScore
+   	episodes
+   	chapters
+   	volumes
+    nextAiringEpisode
+   	season
+   	seasonYear
+   	startDate
+   	endDate
+   	studios
+   	genres
+    siteUrl
+  }
+`;
+
 /** Full media fields with relations — used by existing queries for backward compat. */
 export const MEDIA_FIELDS = `
   ${MEDIA_FIELDS_BASE}

--- a/src/queries/media.ts
+++ b/src/queries/media.ts
@@ -1,4 +1,4 @@
-import { MEDIA_FIELDS, MEDIA_FIELDS_BASE } from "./fragments";
+import { MEDIA_FIELDS, MEDIA_FIELDS_BASE, MEDIA_RECOMMENDATION_FIELDS } from "./fragments";
 
 export const QUERY_MEDIA_BY_ID = `
 query ($id: Int!) {
@@ -137,25 +137,7 @@ query ($mediaId: Int!, $page: Int, $perPage: Int, $sort: [RecommendationSort]) {
     recommendations(page: $page, perPage: $perPage, sort: $sort) {
       pageInfo { total perPage currentPage lastPage hasNextPage }
       nodes {
-        id
-        rating
-        userRating
-        mediaRecommendation {
-          id
-          idMal
-          title { romaji english native userPreferred }
-          type
-          format
-          status
-          coverImage { extraLarge large medium color }
-          bannerImage
-          genres
-          averageScore
-          meanScore
-          popularity
-          favourites
-          siteUrl
-        }
+        ${MEDIA_RECOMMENDATION_FIELDS}
         user {
           id
           name

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -168,6 +168,7 @@ export interface MediaEdge {
     | "coverImage"
     | "genres"
     | "averageScore"
+    | "meanScore"
     | "studios"
     | "siteUrl"
     | "nextAiringEpisode"

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -222,7 +222,27 @@ export interface MediaStats {
 export interface MediaRecommendationNode {
   id: number;
   rating: number | null;
-  mediaRecommendation: Pick<Media, "id" | "title" | "type" | "format" | "coverImage" | "averageScore" | "siteUrl">;
+  mediaRecommendation: Pick<
+    Media,
+    | "id"
+    | "title"
+    | "type"
+    | "format"
+    | "coverImage"
+    | "averageScore"
+    | "meanScore"
+    | "episodes"
+    | "chapters"
+    | "volumes"
+    | "nextAiringEpisode"
+    | "season"
+    | "seasonYear"
+    | "startDate"
+    | "endDate"
+    | "studios"
+    | "genres"
+    | "siteUrl"
+  >;
 }
 
 export interface NextAiringEpisode {

--- a/tests/unit/__snapshots__/snapshots.test.ts.snap
+++ b/tests/unit/__snapshots__/snapshots.test.ts.snap
@@ -809,17 +809,30 @@ query ($id: Int!) {
 
     recommendations(perPage: 5, sort: [RATING_DESC]) {
       nodes {
-        id
-        rating
-        mediaRecommendation {
-          id
-          title { romaji english native userPreferred }
-          type
-          format
-          coverImage { large medium }
-          averageScore
-          siteUrl
-        }
+        
+  id
+  rating
+  mediaRecommendation {
+    id
+    title { romaji english native userPreferred }
+    type
+    format
+    coverImage { large medium }
+    averageScore
+    meanScore
+   	episodes
+   	chapters
+   	volumes
+    nextAiringEpisode
+   	season
+   	seasonYear
+   	startDate
+   	endDate
+   	studios
+   	genres
+    siteUrl
+  }
+
       }
     }
 

--- a/tests/unit/__snapshots__/snapshots.test.ts.snap
+++ b/tests/unit/__snapshots__/snapshots.test.ts.snap
@@ -127,6 +127,7 @@ query ($idMal: Int!, $type: MediaType) {
         coverImage { extraLarge large medium color }
         genres
         averageScore
+        meanScore
         studios { nodes { id name isAnimationStudio siteUrl } }
         siteUrl
         nextAiringEpisode {
@@ -461,6 +462,7 @@ exports[`query snapshots > buildBatchMediaQuery matches snapshot 1`] = `
         coverImage { extraLarge large medium color }
         genres
         averageScore
+        meanScore
         studios { nodes { id name isAnimationStudio siteUrl } }
         siteUrl
         nextAiringEpisode {
@@ -538,6 +540,7 @@ exports[`query snapshots > buildBatchMediaQuery matches snapshot 1`] = `
         coverImage { extraLarge large medium color }
         genres
         averageScore
+        meanScore
         studios { nodes { id name isAnimationStudio siteUrl } }
         siteUrl
         nextAiringEpisode {
@@ -615,6 +618,7 @@ exports[`query snapshots > buildBatchMediaQuery matches snapshot 1`] = `
         coverImage { extraLarge large medium color }
         genres
         averageScore
+        meanScore
         studios { nodes { id name isAnimationStudio siteUrl } }
         siteUrl
         nextAiringEpisode {
@@ -737,6 +741,7 @@ query ($id: Int!) {
         coverImage { extraLarge large medium color }
         genres
         averageScore
+        meanScore
         studios { nodes { id name isAnimationStudio siteUrl } }
         siteUrl
         nextAiringEpisode {
@@ -978,6 +983,7 @@ query ($id: Int!) {
         coverImage { extraLarge large medium color }
         genres
         averageScore
+        meanScore
         studios { nodes { id name isAnimationStudio siteUrl } }
         siteUrl
         nextAiringEpisode {


### PR DESCRIPTION
I went ahead and created a new fragment for Media Recommendation Fields as I noticed they are inconsistent for the getRecommendations endpoint and the option when getting by ID.

I also added more fields that I need for my application.

And I also added in Mean Score to MediaEdge so it can be a fallback when average score is not returned. Useful for manga that has not been scored a lot.

Unit tests with new snapshots all passed.