### PR TITLE
Exclude Media by ID in endpoints

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -60,7 +60,7 @@ Search for anime or manga with filters. Supports single and multi-criteria genre
 | --- | --- |
 | `options` | `SearchMediaOptions` |
 
-**Key options:** `query`, `countryOfOrigin`, `type`, `format`, `status`, `season`, `genre`, `tag`, `genres`, `tags`, `genresExclude`, `tagsExclude`, `isAdult`, `sort`, `page`, `perPage`
+**Key options:** `query`, `countryOfOrigin`, `type`, `format`, `status`, `season`, `genre`, `tag`, `genres`, `tags`, `genresExclude`, `tagsExclude`, `isAdult`, `idNotIn`, `sort`, `page`, `perPage`
 
 **Returns:** `Promise<PagedResult<Media>>`
 
@@ -82,7 +82,7 @@ Get currently trending anime or manga.
 | --- | --- |
 | `options` | `GeneralMediaQueryOptions` |
 
-**Key options:** `type`, `isAdult`, `page`, `perPage`
+**Key options:** `type`, `isAdult`, `idNotIn`, `page`, `perPage`
 
 **Returns:** `Promise<PagedResult<Media>>`
 
@@ -94,7 +94,7 @@ Get the most popular anime or manga. Convenience wrapper around `searchMedia` wi
 | --- | --- |
 | `options` | `GeneralMediaQueryOptions` |
 
-**Key options:** `type`, `isAdult`, `page`, `perPage`
+**Key options:** `type`, `isAdult`, `idNotIn`, `page`, `perPage`
 
 **Returns:** `Promise<PagedResult<Media>>`
 
@@ -110,7 +110,7 @@ Get the highest-rated anime or manga. Convenience wrapper around `searchMedia` w
 | --- | --- |
 | `options` | `GeneralMediaQueryOptions` |
 
-**Key options:** `type`, `isAdult`, `page`, `perPage`
+**Key options:** `type`, `isAdult`, `idNotIn`, `page`, `perPage`
 
 **Returns:** `Promise<PagedResult<Media>>`
 
@@ -118,7 +118,7 @@ Get the highest-rated anime or manga. Convenience wrapper around `searchMedia` w
 const top = await client.getTopRated(MediaType.MANGA, 1, 10);
 ```
 
-### `getWeeklySchedule(date?, isAdult?)`
+### `getWeeklySchedule(date?)`
 
 Fetches the airing schedule for the entire week of the specified date (defaults to the current week). Returns a `WeeklySchedule` object grouped by day of the week.
 
@@ -130,7 +130,7 @@ Get anime/manga for a specific season + year.
 
 | Param | Type |
 | --- | --- |
-| `options` | `GetSeasonOptions` (season, seasonYear, type?, isAdult?, sort?, page?, perPage?) |
+| `options` | `GetSeasonOptions` (season, seasonYear, type?, isAdult?, idNotIn?, sort?, page?, perPage?) |
 
 **Returns:** `Promise<PagedResult<Media>>`
 
@@ -140,7 +140,7 @@ Get upcoming (not yet released) media sorted by popularity.
 
 | Param | Type |
 | --- | --- |
-| `options` | `GetPlanningOptions` (type?, isAdult?, sort?, page?, perPage?) |
+| `options` | `GetPlanningOptions` (type?, isAdult?, idNotIn?, sort?, page?, perPage?) |
 
 **Returns:** `Promise<PagedResult<Media>>`
 
@@ -150,7 +150,7 @@ Get recently aired anime episodes (default: last 24 hours).
 
 | Param | Type |
 | --- | --- |
-| `options` | `GetAiringOptions` (airingAtGreater?, airingAtLesser?, isAdult?, sort?, page?, perPage?) |
+| `options` | `GetAiringOptions` (airingAtGreater?, airingAtLesser?, isAdult?, idNotIn?, sort?, page?, perPage?) |
 
 **Returns:** `Promise<PagedResult<AiringSchedule>>`
 
@@ -160,7 +160,7 @@ Get currently releasing manga sorted by most recently updated.
 
 | Param | Type |
 | --- | --- |
-| `options` | `GetAiringOptions` (isAdult?, page?, perPage?) |
+| `options` | `GetAiringOptions` (isAdult?, idNotIn?, page?, perPage?) |
 
 **Returns:** `Promise<PagedResult<Media>>`
 

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -327,6 +327,7 @@ Represents an animation studio. Fields `favourites` and `media` are populated wh
 | `genresExclude` | `string[]` | Exclude genres |
 | `tagsExclude` | `string[]` | Exclude tags |
 | `isAdult` | `boolean` | Include/exclude adult content |
+| `idNotIn` | `number[]` | Exclude certain media entries by ID |
 | `sort` | `MediaSort[]` | Sort order |
 | `page` | `number` | Page number |
 | `perPage` | `number` | Results per page (max 50) |

--- a/src/client/media.ts
+++ b/src/client/media.ts
@@ -115,18 +115,22 @@ export async function searchMedia(client: ClientBase, options: SearchMediaOption
 }
 
 export async function getTrending(client: ClientBase, options: GeneralMediaQueryOptions): Promise<PagedResult<Media>> {
-  const { type = MediaType.ANIME, isAdult = false, page = 1, perPage = 20 } = options;
-  return client.pagedRequest<Media>(QUERY_TRENDING, { type, isAdult, page, perPage: clampPerPage(perPage) }, "media");
+  const { type = MediaType.ANIME, isAdult = false, idNotIn = [], page = 1, perPage = 20 } = options;
+  return client.pagedRequest<Media>(
+    QUERY_TRENDING,
+    { type, isAdult, idNotIn, page, perPage: clampPerPage(perPage) },
+    "media",
+  );
 }
 
 export async function getPopular(client: ClientBase, options: GeneralMediaQueryOptions): Promise<PagedResult<Media>> {
-  const { type = MediaType.ANIME, isAdult = false, page = 1, perPage = 20 } = options;
-  return searchMedia(client, { type, isAdult, sort: [MediaSort.POPULARITY_DESC], page, perPage });
+  const { type = MediaType.ANIME, isAdult = false, idNotIn = [], page = 1, perPage = 20 } = options;
+  return searchMedia(client, { type, isAdult, idNotIn, sort: [MediaSort.POPULARITY_DESC], page, perPage });
 }
 
 export async function getTopRated(client: ClientBase, options: GeneralMediaQueryOptions): Promise<PagedResult<Media>> {
-  const { type = MediaType.ANIME, isAdult = false, page = 1, perPage = 20 } = options;
-  return searchMedia(client, { type, isAdult, sort: [MediaSort.SCORE_DESC], page, perPage });
+  const { type = MediaType.ANIME, isAdult = false, idNotIn = [], page = 1, perPage = 20 } = options;
+  return searchMedia(client, { type, isAdult, idNotIn, sort: [MediaSort.SCORE_DESC], page, perPage });
 }
 
 export async function getAiredEpisodes(
@@ -139,7 +143,7 @@ export async function getAiredEpisodes(
     {
       airingAt_greater: options.airingAtGreater ?? now - 24 * 3600,
       airingAt_lesser: options.airingAtLesser ?? now,
-      isAdult: options.isAdult ?? false,
+      idNotIn: options.idNotIn ?? [],
       sort: options.sort,
       page: options.page ?? 1,
       perPage: clampPerPage(options.perPage ?? 20),
@@ -156,6 +160,7 @@ export async function getRecentlyUpdatedManga(
     QUERY_RECENT_CHAPTERS,
     {
       isAdult: options.isAdult ?? false,
+      idNotIn: options.idNotIn ?? [],
       page: options.page ?? 1,
       perPage: clampPerPage(options.perPage ?? 20),
     },
@@ -169,6 +174,7 @@ export async function getPlanning(client: ClientBase, options: GetPlanningOption
     {
       type: options.type,
       isAdult: options.isAdult ?? false,
+      idNotIn: options.idNotIn ?? [],
       sort: options.sort ?? [MediaSort.POPULARITY_DESC],
       page: options.page ?? 1,
       perPage: clampPerPage(options.perPage ?? 20),
@@ -211,6 +217,7 @@ export async function getMediaBySeason(client: ClientBase, options: GetSeasonOpt
       seasonYear: options.seasonYear,
       type: options.type,
       isAdult: options.isAdult ?? false,
+      idNotIn: options.idNotIn ?? [],
       sort: options.sort,
       page: options.page ?? 1,
       perPage: clampPerPage(options.perPage ?? 20),
@@ -222,7 +229,7 @@ export async function getMediaBySeason(client: ClientBase, options: GetSeasonOpt
 export async function getWeeklySchedule(
   client: ClientBase,
   date: Date = new Date(),
-  isAdult: boolean = false,
+  idNotIn?: number[],
 ): Promise<WeeklySchedule> {
   const schedule: WeeklySchedule = {
     Monday: [],
@@ -250,7 +257,7 @@ export async function getWeeklySchedule(
       getAiredEpisodes(client, {
         airingAtGreater: startTimestamp,
         airingAtLesser: endTimestamp,
-        isAdult,
+        idNotIn,
         page,
         perPage: 50,
       }),

--- a/src/queries/media.ts
+++ b/src/queries/media.ts
@@ -24,6 +24,7 @@ query (
   $genre_not_in: [String],
   $tag_not_in: [String],
   $isAdult: Boolean,
+  $idNotIn: [Int],
   $sort: [MediaSort],
   $page: Int,
   $perPage: Int
@@ -46,6 +47,7 @@ query (
       genre_not_in: $genre_not_in,
       tag_not_in: $tag_not_in,
       isAdult: $isAdult,
+      id_not_in: $idNotIn,
       sort: $sort
     ) {
       ${MEDIA_FIELDS_BASE}
@@ -54,20 +56,43 @@ query (
 }`;
 
 export const QUERY_TRENDING = `
-query ($type: MediaType, $isAdult: Boolean, $page: Int, $perPage: Int) {
+query (
+  $type: MediaType,
+  $isAdult: Boolean,
+  $idNotIn: [Int],
+  $page: Int,
+  $perPage: Int
+) {
   Page(page: $page, perPage: $perPage) {
     pageInfo { total perPage currentPage lastPage hasNextPage }
-    media(type: $type, isAdult: $isAdult, sort: TRENDING_DESC) {
+    media(
+      type: $type,
+      isAdult: $isAdult,
+      id_not_in: $idNotIn,
+      sort: TRENDING_DESC
+    ) {
       ${MEDIA_FIELDS_BASE}
     }
   }
 }`;
 
 export const QUERY_AIRING_SCHEDULE = `
-query ($airingAt_greater: Int, $airingAt_lesser: Int, $isAdult: Boolean, $sort: [AiringSort], $page: Int, $perPage: Int) {
+query (
+  $airingAt_greater: Int,
+  $airingAt_lesser: Int,
+  $sort: [AiringSort],
+  $idNotIn: [Int],
+  $page: Int,
+  $perPage: Int
+) {
   Page(page: $page, perPage: $perPage) {
     pageInfo { total perPage currentPage lastPage hasNextPage }
-    airingSchedules(airingAt_greater: $airingAt_greater, airingAt_lesser: $airingAt_lesser, sort: $sort) {
+    airingSchedules(
+      airingAt_greater: $airingAt_greater,
+      airingAt_lesser: $airingAt_lesser,
+      id_not_in: $idNotIn,
+      sort: $sort
+    ) {
       id
       airingAt
       timeUntilAiring
@@ -81,20 +106,44 @@ query ($airingAt_greater: Int, $airingAt_lesser: Int, $isAdult: Boolean, $sort: 
 }`;
 
 export const QUERY_RECENT_CHAPTERS = `
-query ($isAdult: Boolean $page: Int, $perPage: Int) {
+query (
+  $isAdult: Boolean,
+  $idNotIn: [Int],
+  $page: Int,
+  $perPage: Int
+) {
   Page(page: $page, perPage: $perPage) {
     pageInfo { total perPage currentPage lastPage hasNextPage }
-    media(type: MANGA, isAdult: $isAdult status: RELEASING, sort: UPDATED_AT_DESC) {
+    media(
+      type: MANGA,
+      isAdult: $isAdult,
+      id_not_in: $idNotIn,
+      status: RELEASING,
+      sort: UPDATED_AT_DESC
+    ) {
       ${MEDIA_FIELDS_BASE}
     }
   }
 }`;
 
 export const QUERY_PLANNING = `
-query ($type: MediaType, $isAdult: Boolean, $sort: [MediaSort], $page: Int, $perPage: Int) {
+query (
+  $type: MediaType,
+  $isAdult: Boolean,
+  $idNotIn: [Int],
+  $sort: [MediaSort],
+  $page: Int,
+  $perPage: Int
+) {
   Page(page: $page, perPage: $perPage) {
     pageInfo { total perPage currentPage lastPage hasNextPage }
-    media(type: $type, isAdult: $isAdult, status: NOT_YET_RELEASED, sort: $sort) {
+    media(
+      type: $type,
+      isAdult: $isAdult,
+      id_not_in: $idNotIn,
+      status: NOT_YET_RELEASED,
+      sort: $sort
+    ) {
       ${MEDIA_FIELDS_BASE}
     }
   }
@@ -106,6 +155,7 @@ query (
   $seasonYear: Int!,
   $type: MediaType,
   $isAdult: Boolean,
+  $idNotIn: [Int],
   $sort: [MediaSort],
   $page: Int,
   $perPage: Int
@@ -117,6 +167,7 @@ query (
       seasonYear: $seasonYear,
       type: $type,
       isAdult: $isAdult,
+      id_not_in: $idNotIn,
       sort: $sort
     ) {
       ${MEDIA_FIELDS_BASE}

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -306,6 +306,8 @@ export interface SearchMediaOptions {
   tagsExclude?: string[];
   /** Include or Exclude explicit content (default: false) */
   isAdult?: boolean;
+  /** Exclude certain media entries by ID */
+  idNotIn?: number[];
   /** Sort order */
   sort?: MediaSort[];
   /** Page number */
@@ -319,6 +321,8 @@ export interface GeneralMediaQueryOptions {
   type?: MediaType;
   /** Include or Exclude explicit content (default: false) */
   isAdult?: boolean;
+  /** Exclude certain media entries by ID */
+  idNotIn?: number[];
   /** Page number */
   page?: number;
   /** Results per page (max 50) */
@@ -330,8 +334,8 @@ export interface GetAiringOptions {
   airingAtGreater?: number;
   /** Only show episodes that aired before this UNIX timestamp */
   airingAtLesser?: number;
-  /** Include or Exclude explicit content (default: false) */
-  isAdult?: boolean;
+  /** Exclude certain media entries by ID */
+  idNotIn?: number[];
   /** Sort order (default: TIME_DESC) */
   sort?: AiringSort[];
   /** Page number */
@@ -343,6 +347,8 @@ export interface GetAiringOptions {
 export interface GetRecentChaptersOptions {
   /** Include or Exclude explicit content (default: false) */
   isAdult?: boolean;
+  /** Exclude certain media entries by ID */
+  idNotIn?: number[];
   /** Page number (default: 1) */
   page?: number;
   /** Results per page (default: 20, max 50) */
@@ -354,6 +360,8 @@ export interface GetPlanningOptions {
   type?: MediaType;
   /** Include or Exclude explicit content (default: false) */
   isAdult?: boolean;
+  /** Exclude certain media entries by ID */
+  idNotIn?: number[];
   /** Sort order (default: POPULARITY_DESC) */
   sort?: MediaSort[];
   /** Page number */
@@ -401,6 +409,8 @@ export interface GetSeasonOptions {
   type?: MediaType;
   /** Allow or disallow explicit content (defaults to False) */
   isAdult?: boolean;
+  /** Exclude certain media entries by ID */
+  idNotIn?: number[];
   /** Sort order (default: POPULARITY_DESC) */
   sort?: MediaSort[];
   /** Page number */

--- a/tests/unit/__snapshots__/snapshots.test.ts.snap
+++ b/tests/unit/__snapshots__/snapshots.test.ts.snap
@@ -2,10 +2,22 @@
 
 exports[`query snapshots > QUERY_AIRING_SCHEDULE matches snapshot 1`] = `
 "
-query ($airingAt_greater: Int, $airingAt_lesser: Int, $isAdult: Boolean, $sort: [AiringSort], $page: Int, $perPage: Int) {
+query (
+  $airingAt_greater: Int,
+  $airingAt_lesser: Int,
+  $sort: [AiringSort],
+  $idNotIn: [Int],
+  $page: Int,
+  $perPage: Int
+) {
   Page(page: $page, perPage: $perPage) {
     pageInfo { total perPage currentPage lastPage hasNextPage }
-    airingSchedules(airingAt_greater: $airingAt_greater, airingAt_lesser: $airingAt_lesser, sort: $sort) {
+    airingSchedules(
+      airingAt_greater: $airingAt_greater,
+      airingAt_lesser: $airingAt_lesser,
+      id_not_in: $idNotIn,
+      sort: $sort
+    ) {
       id
       airingAt
       timeUntilAiring
@@ -163,6 +175,7 @@ query (
   $genre_not_in: [String],
   $tag_not_in: [String],
   $isAdult: Boolean,
+  $idNotIn: [Int],
   $sort: [MediaSort],
   $page: Int,
   $perPage: Int
@@ -185,6 +198,7 @@ query (
       genre_not_in: $genre_not_in,
       tag_not_in: $tag_not_in,
       isAdult: $isAdult,
+      id_not_in: $idNotIn,
       sort: $sort
     ) {
       
@@ -265,10 +279,21 @@ query ($search: String, $sort: [StudioSort], $page: Int, $perPage: Int) {
 
 exports[`query snapshots > QUERY_TRENDING matches snapshot 1`] = `
 "
-query ($type: MediaType, $isAdult: Boolean, $page: Int, $perPage: Int) {
+query (
+  $type: MediaType,
+  $isAdult: Boolean,
+  $idNotIn: [Int],
+  $page: Int,
+  $perPage: Int
+) {
   Page(page: $page, perPage: $perPage) {
     pageInfo { total perPage currentPage lastPage hasNextPage }
-    media(type: $type, isAdult: $isAdult, sort: TRENDING_DESC) {
+    media(
+      type: $type,
+      isAdult: $isAdult,
+      id_not_in: $idNotIn,
+      sort: TRENDING_DESC
+    ) {
       
   id
   idMal


### PR DESCRIPTION
### **What I did:**
I went ahead and added in an idNotIn param of type number[]. This should exclude entries from the query if you pass in an array of media IDs. I did this for various media endpoints:
- `searchMedia`
- `getTrending`
- `getPopular`
- `getTopRated`
- `getMediaBySeason`
- `getPlanning`
- `getAiredEpisodes`
- `getRecentlyUpdatedManga`

I also updated the `getWeeklySchedule` endpoint, and removed the isAdult field, as there is not an option for that query to filter out by isAdult. I did not do this in a separate commit by accident, however this does not necessarily break anything, as the param was not functionally doing anything to begin with.

All unit tests pass, and theoretically this should work as expected, however I have not written any unit tests to confirm this. 

### **Why it's useful:**
This can allow you to filter out media that may be in your list, or blacklist certain media from queries, etc.